### PR TITLE
Fix: Allow multiple sl in params

### DIFF
--- a/lib/spree/search/searchkick.rb
+++ b/lib/spree/search/searchkick.rb
@@ -79,7 +79,7 @@ module Spree
         super
         @properties[:ignore_search] = params[:ignore_search]
         @properties[:producer] = params[:producer]
-        @properties[:stock_location_ids] = params[:stock_location_ids]
+        @properties[:stock_location_ids] = params[:stock_location_ids].split(',').compact.uniq
         @properties[:current_store_id] = params[:current_store_id]
         taxon_ids = [taxon]
         if params[:property].present?


### PR DESCRIPTION
La api se rompe al enviar multiples sl en el query a elasticsearch

<img width="843" alt="image" src="https://github.com/chinoxchen-spree-contrib/spree_searchkick/assets/19697766/4d650e47-1937-47eb-ac8b-f884778c6ec1">
